### PR TITLE
feat(auth): Add configurable OAuth callback URLs via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ DATABASE_URL="postgresql://postgres.[project-ref]:[password]@aws-0-[region].pool
 NEXT_PUBLIC_SUPABASE_URL="https://[project-ref].supabase.co"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key"
 
+# App URL (for OAuth callbacks)
+# Development: http://localhost:3000
+# Production: https://yourdomain.com
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
 # Meta API Configuration
 # Set to "true" to use mock data (no Meta API calls)
 # Set to "false" to use real Meta Graph API (requires Meta OAuth setup)

--- a/packages/auth/src/providers.ts
+++ b/packages/auth/src/providers.ts
@@ -26,6 +26,14 @@ export interface EmailAuthResult {
 }
 
 /**
+ * Get the base URL for OAuth callbacks.
+ * Prioritizes NEXT_PUBLIC_APP_URL env variable, falls back to window.location.origin.
+ */
+function getBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL || window.location.origin;
+}
+
+/**
  * Sign in with Facebook OAuth.
  * This will redirect the user to Facebook for authentication.
  */
@@ -37,7 +45,7 @@ export async function signInWithFacebook(
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: "facebook",
     options: {
-      redirectTo: options?.redirectTo ?? `${window.location.origin}/auth/callback`,
+      redirectTo: options?.redirectTo ?? `${getBaseUrl()}/auth/callback`,
       scopes: options?.scopes ?? "email,public_profile",
       queryParams: options?.queryParams,
     },
@@ -58,7 +66,7 @@ export async function signInWithGoogle(
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: "google",
     options: {
-      redirectTo: options?.redirectTo ?? `${window.location.origin}/auth/callback`,
+      redirectTo: options?.redirectTo ?? `${getBaseUrl()}/auth/callback`,
       scopes: options?.scopes,
       queryParams: {
         access_type: "offline",
@@ -83,7 +91,7 @@ export async function signInWithOAuth(
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
     options: {
-      redirectTo: options?.redirectTo ?? `${window.location.origin}/auth/callback`,
+      redirectTo: options?.redirectTo ?? `${getBaseUrl()}/auth/callback`,
       scopes: options?.scopes,
       queryParams: options?.queryParams,
     },
@@ -147,7 +155,7 @@ export async function signUpWithEmail(
     email,
     password,
     options: {
-      emailRedirectTo: options?.emailRedirectTo ?? `${window.location.origin}/auth/callback`,
+      emailRedirectTo: options?.emailRedirectTo ?? `${getBaseUrl()}/auth/callback`,
       data: options?.data,
     },
   });
@@ -196,7 +204,7 @@ export async function resetPasswordForEmail(
   const supabase = getSupabaseClient();
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: options?.redirectTo ?? `${window.location.origin}/auth/callback?type=recovery`,
+    redirectTo: options?.redirectTo ?? `${getBaseUrl()}/auth/callback?type=recovery`,
   });
 
   return { error };

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,7 @@
         "DATABASE_URL",
         "NEXT_PUBLIC_SUPABASE_URL",
         "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "NEXT_PUBLIC_APP_URL",
         "NEXT_PUBLIC_USE_MOCK_META_API",
         "GROQ_API_KEY"
       ]


### PR DESCRIPTION
Add NEXT_PUBLIC_APP_URL environment variable to configure OAuth callback URLs across different environments (development/production). This enables proper Google Auth and other OAuth provider configuration without hardcoding URLs.

Changes:
- Add NEXT_PUBLIC_APP_URL to .env.example with documentation
- Update auth providers to use getBaseUrl() helper that prioritizes env variable
- Add NEXT_PUBLIC_APP_URL to turbo.json env array for proper cache invalidation
- Apply to all OAuth flows: Google, Facebook, email signup, and password reset